### PR TITLE
Fix OOC and job-whitelist checks using the wrong whitelist system

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -198,7 +198,7 @@ SUBSYSTEM_DEF(job)
 			JobDebug("FOC player did not pass special check, Player: [player], Job:[job.title]")
 			continue
 		if(CONFIG_GET(flag/usewhitelist))
-			if(job.whitelist_req && (!player.client.whitelisted()))
+			if(job.whitelist_req && !check_whitelist(player.client.ckey))
 				continue
 		if(player.client.prefs.job_preferences[job.title] == level)
 			JobDebug("FOC pass, Player: [player], Level:[level]")
@@ -297,7 +297,7 @@ SUBSYSTEM_DEF(job)
 			continue
 
 		if(CONFIG_GET(flag/usewhitelist))
-			if(job.whitelist_req && (!player.client.whitelisted()))
+			if(job.whitelist_req && !check_whitelist(player.client.ckey))
 				continue
 
 //		if((player.client.prefs.lastclass == job.title) && (!job.bypass_lastclass))
@@ -537,7 +537,7 @@ SUBSYSTEM_DEF(job)
 					continue
 
 				if(CONFIG_GET(flag/usewhitelist))
-					if(job.whitelist_req && (!player.client.whitelisted()))
+					if(job.whitelist_req && !check_whitelist(player.client.ckey))
 						continue
 
 				if(length(job.allowed_ages) && !(player.client.prefs.age in job.allowed_ages))
@@ -638,7 +638,7 @@ SUBSYSTEM_DEF(job)
 					continue
 
 				if(CONFIG_GET(flag/usewhitelist))
-					if(job.whitelist_req && (!player.client.whitelisted()))
+					if(job.whitelist_req && !check_whitelist(player.client.ckey))
 						continue
 
 				if(length(job.allowed_ages) && !(player.client.prefs.age in job.allowed_ages))

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -14,10 +14,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(!mob)
 		return
 
-	if(CONFIG_GET(flag/usewhitelist))
-		if(whitelisted() != 1)
-			to_chat(src, span_danger("I can't use that."))
-			return
+	if(!holder && CONFIG_GET(flag/usewhitelist) && !check_whitelist(ckey))
+		to_chat(src, span_danger("I can't use that."))
+		return
 
 	if(blacklisted())
 		to_chat(src, span_danger("I can't use that."))
@@ -139,10 +138,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(!mob)
 		return
 
-	if(CONFIG_GET(flag/usewhitelist))
-		if(whitelisted() != 1)
-			to_chat(src, span_danger("I can't use that."))
-			return
+	if(!holder && CONFIG_GET(flag/usewhitelist) && !check_whitelist(ckey))
+		to_chat(src, span_danger("I can't use that."))
+		return
 
 	if(blacklisted())
 		to_chat(src, span_danger("I can't use that."))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -293,7 +293,7 @@ GLOBAL_LIST_INIT(roleplay_readme, world.file2list("strings/rt/rp_prompt.txt"))
 	if(!job)
 		return JOB_UNAVAILABLE_GENERIC
 	if(CONFIG_GET(flag/usewhitelist))
-		if(job.whitelist_req && !client.whitelisted())
+		if(job.whitelist_req && !check_whitelist(client.ckey))
 			return JOB_UNAVAILABLE_GENERIC
 	if(!job.bypass_jobban)
 		if(is_banned_from(ckey, rank))


### PR DESCRIPTION
This PR fixes the bug introduced by the SQL whitelist PR where OOC and jobs wasn't working due to it using a different function compared to base AP. 